### PR TITLE
Update README: Fix nano installation using scoop

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ irm get.scoop.sh | iex
 2. Add nano for Windows directly from its bucket:
 ```pwsh
 scoop bucket add .oki https://github.com/okibcn/Bucket  # Optional: the changes are propagated faster this way
+scoop install curl # Installing curl will also install 7zip to prevent nano zip archive issue installation.
 scoop install nano
 ```
 To remove the app, type:


### PR DESCRIPTION
When installing nano through scoop, almost all user will end up with "The archive entry was compressed using an unsupported compression method" error, which prevent us from using it.

The issue filled here: https://github.com/ScoopInstaller/Scoop/issues/5507 which brought up a workaround to fix the installation error.

This also solve:
https://github.com/okibcn/nano-for-windows/issues/34
https://github.com/okibcn/nano-for-windows/issues/39