### PR TITLE
Update Xbuild4Windows.yml

### DIFF
--- a/.github/workflows/Xbuild4Windows.yml
+++ b/.github/workflows/Xbuild4Windows.yml
@@ -507,7 +507,7 @@ jobs:
           llvm-strip -s nano.exe
           upx nano.exe || true
           ls -als
-          7z a -mx9 -mm=Deflate64 -mmt$(nproc) "$CWD/nano-for-windows_${{matrix.name}}_${{ needs.checks.outputs.build }}.zip" * .nanorc
+          7z a -mx9 -mm=Deflate -mmt$(nproc) "$CWD/nano-for-windows_${{matrix.name}}_${{ needs.checks.outputs.build }}.zip" * .nanorc
 
     - name: "👍 Upload Artifact nano-for-windows_${{ matrix.name }}_${{ needs.checks.outputs.build }}.zip"
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
Fixes #42. Makes final ZIP file compatible with Windows built-in `tar` cmdline utility and other compression tools that doesn't implement Deflate64.

I tested that ZIP file created with just Deflate and not Deflate64 can be extracted by built-in Windows tar tool in both Windows 11 and WindowsNanoServer docker container.